### PR TITLE
*: fix library build errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,12 +6,12 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_library(topgg
-    src/http/client.cpp
+    src/client.cpp
     src/http/request.cpp
     src/http/response.cpp
-    include/topgg/http/client.hpp
-    include/topgg/http/request.hpp
-    include/topgg/http/response.hpp
+    include/topgg/client.hpp
+    include/topgg/request.hpp
+    include/topgg/response.hpp
 )
 
 target_include_directories(topgg PUBLIC include)
@@ -45,8 +45,6 @@ target_link_libraries(leaderboard PRIVATE
 
 find_package(CURL REQUIRED)
 find_package(nlohmann_json 3.2.0 REQUIRED)
-
-add_subdirectory(third_party/Catch2)
 
 # Uncomment if you want to run unit tests
 # enable_testing()

--- a/include/topgg/client.hpp
+++ b/include/topgg/client.hpp
@@ -2,27 +2,31 @@
 #define TOPGG_CLIENT_HPP
 
 #include <string>
-#include <memory>
 
-#include "http/request.hpp"
-#include "http/response.hpp"
-#include "errors.hpp"
-#include "models.hpp"
+#include "topgg/request.hpp"
+#include "topgg/response.hpp"
+#include "topgg/errors.hpp"
+#include "topgg/models.hpp"
 
 namespace topgg {
 
 class Client {
 public:
-    Client(const std::string& token);
+    Client(const std::string& token, const std::string& botId);
 
+    std::string getBotId() const;
+    std::string getToken() const;
+    std::vector<UserVote> getVotes();
     std::shared_ptr<User> getCurrentUser();
     std::shared_ptr<BotStats> getBotStats();
+    BotStats getStats();
     std::vector<std::shared_ptr<User>> getBotVotes(const std::string& bot_id);
 
 private:
     std::string m_token;
     std::string m_baseUrl = "https://top.gg/api/";
     std::string m_authHeader;
+    std::string m_botId;
     int m_timeout = 5000;
 };
 

--- a/include/topgg/request.hpp
+++ b/include/topgg/request.hpp
@@ -28,7 +28,7 @@ public:
     void setQueryParameter(const std::string& key, const std::string& value);
     void setBody(const std::string& body);
 
-    std::pair<int, std::string> send();
+    std::pair<int, std::string> send() const;
 
 private:
     Method m_method;

--- a/include/topgg/response.hpp
+++ b/include/topgg/response.hpp
@@ -12,10 +12,10 @@ namespace http {
  */
 class Response {
 public:
-    Response(int statusCode, const std::string& body, const std::map<std::string, std::string>& headers);
+    Response(int statusCode, const std::string& body);
 
     int getStatusCode() const;
-    std::string getBody() const;
+    const std::string& getBody() const;
     std::string getHeader(const std::string& key) const;
 
 private:

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1,9 +1,9 @@
 #include "topgg/client.hpp"
-#include "topgg/http/request.hpp"
-#include "topgg/http/response.hpp"
+#include "topgg/request.hpp"
+#include "topgg/response.hpp"
+#include <nlohmann/json.hpp>
 
 #include <sstream>
-#include <stdexcept>
 
 using namespace topgg;
 using namespace topgg::http;
@@ -27,7 +27,9 @@ std::vector<UserVote> Client::getVotes()
 {
     Request request(Request::Method::GET, "https://top.gg/api/bots/" + m_botId + "/votes");
     request.setHeader("Authorization", m_token);
-    auto [statusCode, responseBody] = request.send();
+    auto response = request.send();
+    auto statusCode = response.first;
+    auto responseBody = response.second;
 
     if (statusCode == 200) {
         std::vector<UserVote> votes;
@@ -58,7 +60,9 @@ BotStats Client::getStats()
 {
     Request request(Request::Method::GET, "https://top.gg/api/bots/" + m_botId + "/stats");
     request.setHeader("Authorization", m_token);
-    auto [statusCode, responseBody] = request.send();
+    auto response = request.send();
+    auto statusCode = response.first;
+    auto responseBody = response.second;
 
     if (statusCode == 200) {
         nlohmann::json json = nlohmann::json::parse(responseBody);

--- a/src/http/request.cpp
+++ b/src/http/request.cpp
@@ -1,7 +1,5 @@
-#include "topgg/http/request.hpp"
-
-#include <stdexcept>
-#include <memory>
+#include "topgg/request.hpp"
+#include <curl/curl.h>
 
 using namespace topgg::http;
 
@@ -35,7 +33,9 @@ std::pair<int, std::string> Request::send() const
 
     // Set request headers
     struct curl_slist* headerList = nullptr;
-    for (const auto& [name, value] : m_headers) {
+    for (const auto& header_it : m_headers) {
+        const std::string& name = header_it.first;
+        const std::string& value = header_it.second;
         const std::string header = name + ": " + value;
         headerList = curl_slist_append(headerList, header.c_str());
     }

--- a/src/http/response.cpp
+++ b/src/http/response.cpp
@@ -1,4 +1,4 @@
-#include "topgg/http/response.hpp"
+#include "topgg/response.hpp"
 
 using namespace topgg::http;
 


### PR DESCRIPTION
Fix the build errors in the library, note that this does not fix all errors as the build process also includes the `examples` directory which uses APIs that are not implemented in the library yet (e.g. the `topgg.hpp` header, which is the main header).